### PR TITLE
Improve mobile responsiveness and remove placeholder imagery

### DIFF
--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -1,14 +1,16 @@
 ---
 ---
-<section class="brutal-border border-black bg-[#f5f5f5] px-6 py-16 text-center lg:px-12">
-  <div class="mx-auto flex max-w-4xl flex-col items-center gap-6">
-    <h2 class="font-['Space_Grotesk'] text-4xl font-semibold uppercase tracking-[0.3em]">Ready to provoke the feed?</h2>
-    <p class="max-w-2xl text-sm uppercase tracking-[0.25em] text-black/60">
+<section class="brutal-border border-black bg-[#f5f5f5] px-4 py-14 text-center sm:px-6 lg:px-12">
+  <div class="mx-auto flex max-w-3xl flex-col items-center gap-5">
+    <h2 class="font-['Space_Grotesk'] text-3xl font-semibold uppercase tracking-[0.24em] sm:text-4xl sm:tracking-[0.3em]">
+      Ready to provoke the feed?
+    </h2>
+    <p class="max-w-2xl text-xs uppercase tracking-[0.22em] text-black/60 sm:text-sm sm:tracking-[0.25em]">
       Drop in and we’ll weaponize your persona with brutal clarity.
     </p>
     <a
       href="https://m.me/yjebrands"
-      class="inline-flex items-center gap-3 border border-black bg-black px-8 py-4 font-['Space_Grotesk'] text-sm uppercase tracking-[0.4em] text-white transition hover:bg-[#e53935]"
+      class="inline-flex w-full items-center justify-center gap-3 border border-black bg-black px-6 py-3 font-['Space_Grotesk'] text-xs uppercase tracking-[0.32em] text-white transition hover:bg-[#e53935] sm:w-auto sm:px-8 sm:py-4 sm:text-sm sm:tracking-[0.4em]"
     >
       Chat in Messenger
     </a>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,18 +22,18 @@ const socials = [
   }
 ];
 ---
-<footer class="brutal-border border-black bg-[#f5f5f5] px-6 py-10 lg:px-12">
+<footer class="brutal-border border-black bg-[#f5f5f5] px-4 py-10 sm:px-6 lg:px-12">
   <div class="grid grid-cols-1 gap-8 lg:grid-cols-12">
-    <div class="lg:col-span-6 space-y-3">
-      <span class="font-['Space_Grotesk'] text-xs uppercase tracking-[0.35em] text-black/60">YJE BRANDS</span>
-      <p class="max-w-sm text-sm uppercase tracking-[0.3em] text-black/60">Brutalist cosplay talent branding agency.</p>
-      <p class="text-xs text-black/50">© {new Date().getFullYear()} YJE Brands. All resistance reserved.</p>
+    <div class="space-y-3 lg:col-span-6">
+      <span class="font-['Space_Grotesk'] text-xs uppercase tracking-[0.32em] text-black/60">YJE BRANDS</span>
+      <p class="max-w-sm text-xs uppercase tracking-[0.28em] text-black/60 sm:text-sm sm:tracking-[0.3em]">Brutalist cosplay talent branding agency.</p>
+      <p class="text-[0.7rem] text-black/50 sm:text-xs">© {new Date().getFullYear()} YJE Brands. All resistance reserved.</p>
     </div>
-    <div class="lg:col-span-6 flex flex-wrap items-start gap-4">
+    <div class="flex flex-wrap items-start gap-3 sm:gap-4 lg:col-span-6">
       {socials.map((social) => (
         <a
           href={social.href}
-          class="flex items-center gap-2 border border-black bg-white px-4 py-2 text-xs uppercase tracking-[0.3em] transition hover:bg-[#e53935] hover:text-white"
+          class="flex items-center gap-2 border border-black bg-white px-3 py-2 text-[0.65rem] uppercase tracking-[0.24em] transition hover:bg-[#e53935] hover:text-white sm:px-4 sm:text-xs sm:tracking-[0.3em]"
           target="_blank"
           rel="noreferrer"
         >

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,8 +1,10 @@
 ---
 ---
-<header class="brutal-border sticky top-0 z-20 flex items-center justify-between border-black bg-[#f5f5f5] px-6 py-6 uppercase tracking-[0.2em]">
-  <a href="/" class="font-['Space_Grotesk'] text-sm font-semibold">YJE BRANDS</a>
-  <nav class="flex items-center gap-6 text-xs">
+<header
+  class="brutal-border sticky top-0 z-20 flex flex-col gap-4 border-black bg-[#f5f5f5] px-4 py-4 uppercase tracking-[0.16em] sm:px-6 md:flex-row md:items-center md:justify-between md:tracking-[0.2em]"
+>
+  <a href="/" class="font-['Space_Grotesk'] text-sm font-semibold tracking-[0.24em]">YJE BRANDS</a>
+  <nav class="flex flex-wrap items-center gap-3 text-[0.65rem] sm:text-xs sm:gap-5">
     <a href="/about" class="transition hover:text-[#e53935]">About</a>
     <a href="https://instagram.com" target="_blank" rel="noreferrer" class="transition hover:text-[#e53935]">Instagram</a>
     <a href="https://m.me/yjebrands" target="_blank" rel="noreferrer" class="transition hover:text-[#e53935]">Messenger</a>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,19 +1,19 @@
 ---
 ---
-<section class="brutal-border border-black bg-[#f5f5f5] px-6 py-20 lg:px-12">
-  <div class="grid grid-cols-1 gap-12 lg:grid-cols-12">
+<section class="brutal-border border-black bg-[#f5f5f5] px-4 py-14 sm:px-6 sm:py-16 lg:px-12 lg:py-20">
+  <div class="grid grid-cols-1 gap-10 lg:grid-cols-12 lg:gap-12">
     <div class="lg:col-span-8">
-      <h1 class="font-['Space_Grotesk'] text-5xl font-semibold leading-[0.85] tracking-[-0.02em] sm:text-6xl md:text-7xl">
+      <h1 class="font-['Space_Grotesk'] text-4xl font-semibold leading-[0.85] tracking-[-0.02em] sm:text-5xl md:text-6xl lg:text-7xl">
         RAW. REAL. REBELLIOUS.
       </h1>
     </div>
-    <div class="lg:col-span-4 flex flex-col justify-end gap-6 text-base leading-relaxed">
-      <p class="max-w-xs text-black/70">
+    <div class="lg:col-span-4 flex flex-col justify-end gap-5 text-sm leading-relaxed text-black/70 sm:text-base">
+      <p class="max-w-xl">
         The next-gen cosplay branding collective. We build audacious platforms for creators who perform without filters.
       </p>
       <a
         href="https://m.me/yjebrands"
-        class="inline-flex w-fit items-center gap-3 bg-[#e53935] px-6 py-3 font-['Space_Grotesk'] text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-black"
+        class="inline-flex w-full items-center justify-center gap-3 bg-[#e53935] px-6 py-3 font-['Space_Grotesk'] text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-black sm:w-fit sm:text-sm"
       >
         Chat in Messenger
       </a>

--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -1,14 +1,14 @@
 ---
 const { title, headline, kicker, class: className = '', children } = Astro.props;
 ---
-<section class={`brutal-border border-black bg-[#f5f5f5] px-6 py-12 lg:px-12 ${className}`}>
+<section class={`brutal-border border-black bg-[#f5f5f5] px-4 py-10 sm:px-6 sm:py-12 lg:px-12 ${className}`}>
   {title && (
     <header class="mb-8 flex flex-col gap-2">
       {kicker && <span class="text-xs uppercase tracking-[0.3em] text-black/60">{kicker}</span>}
-      <h2 class="font-['Space_Grotesk'] text-4xl font-semibold leading-[0.95] md:text-5xl">
+      <h2 class="font-['Space_Grotesk'] text-3xl font-semibold leading-[0.95] sm:text-4xl md:text-5xl">
         {title}
       </h2>
-      {headline && <p class="max-w-2xl text-base leading-relaxed text-black/80">{headline}</p>}
+      {headline && <p class="max-w-2xl text-sm leading-relaxed text-black/80 sm:text-base">{headline}</p>}
     </header>
   )}
   {children}

--- a/src/components/TalentGrid.astro
+++ b/src/components/TalentGrid.astro
@@ -2,62 +2,45 @@
 const talents = [
   {
     name: 'NEON VALKYRIE',
-    role: 'Synthwave Siren',
-    image:
-      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1000&q=80'
+    role: 'Synthwave Siren'
   },
   {
     name: 'IRON ROUGE',
-    role: 'Armor Artificer',
-    image:
-      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1000&q=80'
+    role: 'Armor Artificer'
   },
   {
     name: 'VOID LARK',
-    role: 'Galactic Vocalist',
-    image:
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1000&q=80'
+    role: 'Galactic Vocalist'
   },
   {
     name: 'ELECTRIC KITSUNE',
-    role: 'Mythic Hacker',
-    image:
-      'https://images.unsplash.com/photo-1582719478250-8844c0c1c665?auto=format&fit=crop&w=1000&q=80'
+    role: 'Mythic Hacker'
   },
   {
     name: 'CRIMSON ORACLE',
-    role: 'Future Seer',
-    image:
-      'https://images.unsplash.com/photo-1521572163475-b9e0654b8e66?auto=format&fit=crop&w=1000&q=80'
+    role: 'Future Seer'
   },
   {
     name: 'MERCURY NINJA',
-    role: 'Urban Shadow',
-    image:
-      'https://images.unsplash.com/photo-1559563362-c667ba5f5480?auto=format&fit=crop&w=1000&q=80'
+    role: 'Urban Shadow'
   }
 ];
 ---
-<section class="brutal-border border-black bg-[#f5f5f5] px-6 py-12 lg:px-12">
+<section class="brutal-border border-black bg-[#f5f5f5] px-4 py-10 sm:px-6 sm:py-12 lg:px-12">
   <header class="mb-10 flex flex-col gap-3">
     <span class="text-xs uppercase tracking-[0.35em] text-black/60">Talent Index</span>
-    <h2 class="font-['Space_Grotesk'] text-4xl font-semibold leading-[0.95] md:text-5xl">Faces of the rebellion</h2>
-    <p class="max-w-2xl text-sm uppercase tracking-[0.3em] text-black/50">
+    <h2 class="font-['Space_Grotesk'] text-3xl font-semibold leading-[0.95] sm:text-4xl md:text-5xl">Faces of the rebellion</h2>
+    <p class="max-w-2xl text-xs uppercase tracking-[0.25em] text-black/50 sm:text-sm sm:tracking-[0.3em]">
       Brutalist portraits. No gloss, all grit.
     </p>
   </header>
-  <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+  <div class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
     {talents.map((talent) => (
       <figure class="group relative flex flex-col border border-black bg-white">
-        <img
-          src={talent.image}
-          alt={talent.name}
-          loading="lazy"
-          class="aspect-[4/5] w-full object-cover grayscale transition group-hover:grayscale-0"
-        />
+        <div class="aspect-[4/5] w-full bg-[#e5e5e5]" aria-hidden="true"></div>
         <figcaption class="flex flex-col gap-1 border-t border-black bg-[#f5f5f5] px-4 py-4 uppercase">
-          <span class="font-['Space_Grotesk'] text-sm tracking-[0.28em]">{talent.name}</span>
-          <span class="text-xs tracking-[0.4em] text-black/50">{talent.role}</span>
+          <span class="font-['Space_Grotesk'] text-xs tracking-[0.24em] sm:text-sm sm:tracking-[0.28em]">{talent.name}</span>
+          <span class="text-[0.65rem] tracking-[0.32em] text-black/50 sm:text-xs sm:tracking-[0.4em]">{talent.role}</span>
         </figcaption>
       </figure>
     ))}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Section from '../components/Section.astro';
 import Footer from '../components/Footer.astro';
 ---
 <BaseLayout title="About — YJE Brands" description="The story of YJE Brands, the brutalist cosplay talent agency.">
-  <div class="mx-auto grid max-w-[1200px] gap-6 py-6">
+  <div class="mx-auto grid max-w-[1200px] gap-6 px-4 py-6 sm:px-6">
     <Header />
     <Section
       kicker="Origin File"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import CTA from '../components/CTA.astro';
 import Footer from '../components/Footer.astro';
 ---
 <BaseLayout>
-  <div class="mx-auto grid max-w-[1200px] gap-6 py-6">
+  <div class="mx-auto grid max-w-[1200px] gap-6 px-4 py-6 sm:px-6">
     <Header />
     <Hero />
     <Section


### PR DESCRIPTION
## Summary
- reduce padding, font sizes, and layouts across shared sections to improve readability on smaller screens
- adjust header, hero, CTA, and footer interactions so calls-to-action and navigation adapt on mobile devices
- remove irrelevant placeholder imagery from the talent grid and replace it with neutral frames while keeping profile copy intact

## Testing
- npm run build *(fails: Cannot find module '@astrojs/tailwind' imported from 'astro.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68e5015536508333b68bddaa870c03a8