### PR TITLE
Add navigation back to home

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,6 +5,7 @@
 >
   <a href="/" class="font-['Space_Grotesk'] text-sm font-semibold tracking-[0.24em]">YJE BRANDS</a>
   <nav class="flex flex-wrap items-center gap-3 text-[0.65rem] sm:text-xs sm:gap-5">
+    <a href="/" class="transition hover:text-[#e53935]">Home</a>
     <a href="/about" class="transition hover:text-[#e53935]">About</a>
     <a href="https://instagram.com" target="_blank" rel="noreferrer" class="transition hover:text-[#e53935]">Instagram</a>
     <a href="https://m.me/yjebrands" target="_blank" rel="noreferrer" class="transition hover:text-[#e53935]">Messenger</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -23,6 +23,12 @@ import Footer from '../components/Footer.astro';
             Today, our team architects campaigns, stage builds, and cross-platform narratives that keep audiences obsessing. We blend
             brutalist aesthetics with market analytics to turn every drop into a signature moment.
           </p>
+          <a
+            href="/"
+            class="inline-flex w-full items-center justify-center gap-3 border border-black bg-black px-5 py-3 font-['Space_Grotesk'] text-xs uppercase tracking-[0.28em] text-white transition hover:bg-[#e53935] sm:w-auto"
+          >
+            Return Home
+          </a>
         </div>
         <div class="lg:col-span-5 space-y-3 text-sm uppercase tracking-[0.3em]">
           <div class="flex flex-col gap-2 border border-black bg-white px-6 py-6">


### PR DESCRIPTION
## Summary
- add an explicit Home link to the site header navigation
- provide a "Return Home" call-to-action on the About page so visitors can easily go back

## Testing
- npm run build *(fails: Cannot find module '@astrojs/tailwind')*


------
https://chatgpt.com/codex/tasks/task_e_68e504e31f908333afe1822896cffd4f